### PR TITLE
validate the length of the correct object in yajl_tree_get

### DIFF
--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -457,15 +457,17 @@ yajl_val yajl_tree_get(yajl_val n, const char ** path, yajl_type type)
     if (!path) return NULL;
     while (n && *path) {
         unsigned int i;
+        int len;
 
         if (n->type != yajl_t_object) return NULL;
-        for (i = 0; i < n->u.object.len; i++) {
+        len = n->u.object.len;
+        for (i = 0; i < len; i++) {
             if (!strcmp(*path, n->u.object.keys[i])) {
                 n = n->u.object.values[i];
                 break;
             }
         }
-        if (i == n->u.object.len) return NULL;
+        if (i == len) return NULL;
         path++;
     }
     if (n && type != yajl_t_any && type != n->type) n = NULL;


### PR DESCRIPTION
Hi,

Thanks for making this library available!  I always wondered why there weren't more sax-like json parsers.  I'm doing something pretty small at the moment, so the tree api is enough.  Even that is much cleaner than some of the others I've tried to use.

I found a minor bug in the `yajl_tree_get()` function where the length that's compared after the `for` loop is the length of the object that was found (if found), not the object over which the iteration was occurring.

I didn't see any tests for the tree api, so wasn't sure how to add one to the repo.  Would be happy to if there's an easy model.  This change definitely fixes a problem in my app.

Cheers,
Rob.
