### PR TITLE
Bug fixes for reading integers and the ability to read JSON embeded in a zeromq message which is not null terminated

### DIFF
--- a/example/parse_config.c
+++ b/example/parse_config.c
@@ -44,7 +44,7 @@ main(void)
     }
 
     /* we have the whole config file in memory.  let's parse it ... */
-    node = yajl_tree_parse((const char *) fileData, errbuf, sizeof(errbuf));
+    node = yajl_tree_parse((const char *) fileData, 0, errbuf, sizeof(errbuf));
 
     /* parse error handling */
     if (node == NULL) {

--- a/src/api/yajl_tree.h
+++ b/src/api/yajl_tree.h
@@ -102,15 +102,17 @@ struct yajl_val_s
  * Parses an null-terminated string containing JSON data and returns a pointer
  * to the top-level value (root of the parse tree).
  *
- * \param input              Pointer to a null-terminated utf8 string containing
- *                           JSON data.
+ * \param input              Pointer to a utf8 string containing JSON data.
+ * \param input_size         Size of the memory area pointed to by
+ *                           \em input. If \em input_size is
+ *                           \c 0, treat \em input as null-terminated.
  * \param error_buffer       Pointer to a buffer in which an error message will
  *                           be stored if \em yajl_tree_parse fails, or
  *                           \c NULL. The buffer will be initialized before
  *                           parsing, so its content will be destroyed even if
  *                           \em yajl_tree_parse succeeds.
  * \param error_buffer_size  Size of the memory area pointed to by
- *                           \em error_buffer_size. If \em error_buffer_size is
+ *                           \em error_buffer. If \em error_buffer is
  *                           \c NULL, this argument is ignored.
  *
  * \returns Pointer to the top-level value or \c NULL on error. The memory
@@ -118,7 +120,7 @@ struct yajl_val_s
  * null terminated message describing the error in more detail is stored in
  * \em error_buffer if it is not \c NULL.
  */
-YAJL_API yajl_val yajl_tree_parse (const char *input,
+YAJL_API yajl_val yajl_tree_parse (const char *input, size_t input_size,
                                    char *error_buffer, size_t error_buffer_size);
 
 /**

--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -33,13 +33,14 @@
 
  /* same semantics as strtol */
 long long
-yajl_parse_integer(const unsigned char *number, unsigned int length)
+yajl_parse_integer(const unsigned char *number, unsigned int length, const unsigned char **endptr)
 {
     long long ret  = 0;
     long sign = 1;
     const unsigned char *pos = number;
     if (*pos == '-') { pos++; sign = -1; }
     if (*pos == '+') { pos++; }
+	if (endptr) *endptr = NULL;
 
     while (pos < number + length) {
         if ( ret > MAX_VALUE_TO_MULTIPLY ) {
@@ -54,6 +55,7 @@ yajl_parse_integer(const unsigned char *number, unsigned int length)
         ret += (*pos++ - '0');
     }
 
+	if (endptr) *endptr = pos;
     return sign * ret;
 }
 
@@ -279,7 +281,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                                         hand->ctx,(const char *) buf, bufLen));
                         } else if (hand->callbacks->yajl_integer) {
                             long long int i = 0;
-                            i = yajl_parse_integer(buf, bufLen);
+                            i = yajl_parse_integer(buf, bufLen, NULL);
                             if ((i == LLONG_MIN || i == LLONG_MAX) &&
                                 errno == ERANGE)
                             {

--- a/src/yajl_parser.h
+++ b/src/yajl_parser.h
@@ -72,7 +72,7 @@ yajl_render_error_string(yajl_handle hand, const unsigned char * jsonText,
 /* A little built in integer parsing routine with the same semantics as strtol
  * that's unaffected by LOCALE. */
 long long
-yajl_parse_integer(const unsigned char *number, unsigned int length);
+yajl_parse_integer(const unsigned char *number, unsigned int length, const unsigned char **endptr);
 
 
 #endif

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -312,7 +312,7 @@ static int handle_number (void *ctx, const char *string, size_t string_length)
     endptr = NULL;
     errno = 0;
     v->u.number.i = yajl_parse_integer((const unsigned char *) v->u.number.r,
-                                       strlen(v->u.number.r));
+                                       strlen(v->u.number.r), &endptr);
     if ((errno == 0) && (endptr != NULL) && (*endptr == 0))
         v->u.number.flags |= YAJL_NUMBER_INT_VALID;
 
@@ -401,7 +401,7 @@ static int handle_null (void *ctx)
 /*
  * Public functions
  */
-yajl_val yajl_tree_parse (const char *input,
+yajl_val yajl_tree_parse (const char *input, size_t input_size,
                           char *error_buffer, size_t error_buffer_size)
 {
     static const yajl_callbacks callbacks =
@@ -434,7 +434,7 @@ yajl_val yajl_tree_parse (const char *input,
 
     status = yajl_parse(handle,
                         (unsigned char *) input,
-                        strlen (input));
+                        input_size ? input_size : strlen (input));
     status = yajl_complete_parse (handle);
     if (status != yajl_status_ok) {
         if (error_buffer != NULL && error_buffer_size > 0) {
@@ -456,8 +456,8 @@ yajl_val yajl_tree_get(yajl_val n, const char ** path, yajl_type type)
 {
     if (!path) return NULL;
     while (n && *path) {
-        unsigned int i;
-        int len;
+        size_t i;
+        size_t len;
 
         if (n->type != yajl_t_object) return NULL;
         len = n->u.object.len;


### PR DESCRIPTION
Allow parsing of non-null terminated JSON data and fix integer validation logic
- Add input_size to yajl_tree_parse to allow for non-null terminated data
- Add endptr to yajl_parse_integer to fix handle_number in yajl_tree.c
- Fix 64 bit conversion warnings in yajl_tree_get
- Fix a typo in documentation the for the error_buffer_size parameter of yajl_tree_parse
