### PR TITLE
errno not being reset

### DIFF
--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -279,6 +279,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                                         hand->ctx,(const char *) buf, bufLen));
                         } else if (hand->callbacks->yajl_integer) {
                             long long int i = 0;
+                            errno = 0;
                             i = yajl_parse_integer(buf, bufLen);
                             if ((i == LLONG_MIN || i == LLONG_MAX) &&
                                 errno == ERANGE)
@@ -306,6 +307,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                             yajl_buf_clear(hand->decodeBuf);
                             yajl_buf_append(hand->decodeBuf, buf, bufLen);
                             buf = yajl_buf_data(hand->decodeBuf);
+                            errno = 0;
                             d = strtod((char *) buf, NULL);
                             if ((d == HUGE_VAL || d == -HUGE_VAL) &&
                                 errno == ERANGE)


### PR DESCRIPTION
In src/yajl_parser.c errno should be reset before being used/checked in yajl_do_parse(), protecting from misuses of errno outside the function
