### PR TITLE
Make sure we return the proper final state after generation

### DIFF
--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -205,6 +205,7 @@ yajl_gen_integer(yajl_gen g, long long int number)
     g->print(g->ctx, i, (unsigned int)strlen(i));
     APPENDED_ATOM;
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -225,6 +226,7 @@ yajl_gen_double(yajl_gen g, double number)
     g->print(g->ctx, i, (unsigned int)strlen(i));
     APPENDED_ATOM;
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -235,6 +237,7 @@ yajl_gen_number(yajl_gen g, const char * s, size_t l)
     g->print(g->ctx, s, l);
     APPENDED_ATOM;
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -256,6 +259,7 @@ yajl_gen_string(yajl_gen g, const unsigned char * str,
     g->print(g->ctx, "\"", 1);
     APPENDED_ATOM;
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -266,6 +270,7 @@ yajl_gen_null(yajl_gen g)
     g->print(g->ctx, "null", strlen("null"));
     APPENDED_ATOM;
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -278,6 +283,7 @@ yajl_gen_bool(yajl_gen g, int boolean)
     g->print(g->ctx, val, (unsigned int)strlen(val));
     APPENDED_ATOM;
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -291,6 +297,7 @@ yajl_gen_map_open(yajl_gen g)
     g->print(g->ctx, "{", 1);
     if ((g->flags & yajl_gen_beautify)) g->print(g->ctx, "\n", 1);
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -305,6 +312,7 @@ yajl_gen_map_close(yajl_gen g)
     INSERT_WHITESPACE;
     g->print(g->ctx, "}", 1);
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -317,6 +325,7 @@ yajl_gen_array_open(yajl_gen g)
     g->print(g->ctx, "[", 1);
     if ((g->flags & yajl_gen_beautify)) g->print(g->ctx, "\n", 1);
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 
@@ -330,6 +339,7 @@ yajl_gen_array_close(yajl_gen g)
     INSERT_WHITESPACE;
     g->print(g->ctx, "]", 1);
     FINAL_NEWLINE;
+    ENSURE_VALID_STATE;
     return yajl_gen_status_ok;
 }
 


### PR DESCRIPTION
Currently yajl_gen will return `yajl_gen_status_ok` after the following entire snippet is run:

``` c
status = yajl_gen_array_start(enc);
// yajl_gen_status_ok

status = yajl_gen_integer(enc, 1234);
// yajl_gen_status_ok

status = yajl_gen_array_close(enc);
// yajl_gen_status_ok, I expected yajl_gen_generation_complete?
```

Though, it would return the expected status if I were to attempt any further calls to `yajl_gen_*`. This makes it harder for me to know if generation is still in progress as there won't be any further `yajl_gen_*` calls beyond the final  `yajl_gen_array_close` call.

This patch adds the `ENSURE_VALID_STATE` check at the end of each of the `yajl_gen_*` calls, making it so things are checked before and after generator depth has been affected. 