### PR TITLE
yajl_gen_double does not always emit decimal point

### DIFF
--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -222,6 +222,9 @@ yajl_gen_double(yajl_gen g, double number)
     if (isnan(number) || isinf(number)) return yajl_gen_invalid_number;
     INSERT_SEP; INSERT_WHITESPACE;
     sprintf(i, "%.20g", number);
+    if (strspn(i, "0123456789-") == strlen(i)) {
+        strcat(i, ".0");
+    }
     g->print(g->ctx, i, (unsigned int)strlen(i));
     APPENDED_ATOM;
     FINAL_NEWLINE;


### PR DESCRIPTION
When using yajl to generate JSON, it will not include the decimal point on double-precision floating point numbers if only zeros follow the decimal.  This can cause some other lenient JSON parsers to automatically parse such values as an integer rather than a double, which can cause unexpected integer rounding behaviors in that client app if that app was expecting a double to always be parsed.
