### PR TITLE
Remove unnecessary increment inside loop in yajl_string_scan()

### DIFF
--- a/src/yajl_lex.c
+++ b/src/yajl_lex.c
@@ -255,13 +255,12 @@ static size_t
 yajl_string_scan(const unsigned char * buf, size_t len, int utf8check)
 {
     unsigned char mask = IJC|NFP|(utf8check ? NUC : 0);
-    size_t skip = 0;
-    while (skip < len && !(charLookupTable[*buf] & mask))
+    const char *end = buf + len;
+    while (buf < end && !(charLookupTable[*buf] & mask))
     {
-        skip++;
         buf++;
     }
-    return skip;
+    return (len - (end - buf));
 }
 
 static yajl_tok


### PR DESCRIPTION
Untested, but should improve performance a little bit. Prompted by your question in the function comment. :-)
