### PR TITLE
Convenience wrapper for yajl_tree_get

### DIFF
--- a/src/api/yajl_tree.h
+++ b/src/api/yajl_tree.h
@@ -146,16 +146,16 @@ YAJL_API void yajl_tree_free (yajl_val v);
 YAJL_API yajl_val yajl_tree_get(yajl_val parent, const char ** path, yajl_type type);
 
 /**
- * Access a value inside an object.
+ * Access an immediate value inside a tree.
  *
- * \param object the object from which you'd like to extract values.
+ * \param parent the object from which you'd like to extract values.
  * \param key the key of the value in the object
  * \param type the yajl_type of the object you seek, or yajl_t_any if any will do.
  *
  * \returns a pointer to the found value, or NULL if we came up empty.
  *
  */
-YAJL_API yajl_val yajl_object_get(yajl_val object, const char * key, yajl_type type);
+YAJL_API yajl_val yajl_tree_get(yajl_val parent, const char * key, yajl_type type);
 
 /* Various convenience macros to check the type of a `yajl_val` */
 #define YAJL_IS_STRING(v) (((v) != NULL) && ((v)->type == yajl_t_string))

--- a/src/api/yajl_tree.h
+++ b/src/api/yajl_tree.h
@@ -145,6 +145,18 @@ YAJL_API void yajl_tree_free (yajl_val v);
  */
 YAJL_API yajl_val yajl_tree_get(yajl_val parent, const char ** path, yajl_type type);
 
+/**
+ * Access a value inside an object.
+ *
+ * \param object the object from which you'd like to extract values.
+ * \param key the key of the value in the object
+ * \param type the yajl_type of the object you seek, or yajl_t_any if any will do.
+ *
+ * \returns a pointer to the found value, or NULL if we came up empty.
+ *
+ */
+YAJL_API yajl_val yajl_object_get(yajl_val object, const char * key, yajl_type type);
+
 /* Various convenience macros to check the type of a `yajl_val` */
 #define YAJL_IS_STRING(v) (((v) != NULL) && ((v)->type == yajl_t_string))
 #define YAJL_IS_NUMBER(v) (((v) != NULL) && ((v)->type == yajl_t_number))

--- a/src/api/yajl_tree.h
+++ b/src/api/yajl_tree.h
@@ -146,16 +146,16 @@ YAJL_API void yajl_tree_free (yajl_val v);
 YAJL_API yajl_val yajl_tree_get(yajl_val parent, const char ** path, yajl_type type);
 
 /**
- * Access an immediate value inside a tree.
+ * Access a value inside an object.
  *
- * \param parent the object from which you'd like to extract values.
+ * \param object the object from which you'd like to extract values.
  * \param key the key of the value in the object
  * \param type the yajl_type of the object you seek, or yajl_t_any if any will do.
  *
  * \returns a pointer to the found value, or NULL if we came up empty.
  *
  */
-YAJL_API yajl_val yajl_tree_get(yajl_val parent, const char * key, yajl_type type);
+YAJL_API yajl_val yajl_object_get(yajl_val object, const char * key, yajl_type type);
 
 /* Various convenience macros to check the type of a `yajl_val` */
 #define YAJL_IS_STRING(v) (((v) != NULL) && ((v)->type == yajl_t_string))

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -452,7 +452,7 @@ yajl_val yajl_tree_parse (const char *input,
     return (ctx.root);
 }
 
-yajl_val yajl_tree_get(yajl_val n, const char * key, yajl_type type)
+yajl_val yajl_object_get(yajl_val n, const char * key, yajl_type type)
 {
   const char ** path = {key, 0};
   yajl_val v = yajl_tree_get(n, path, type);

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -452,6 +452,13 @@ yajl_val yajl_tree_parse (const char *input,
     return (ctx.root);
 }
 
+yajl_val yajl_object_get(yajl_val n, const char * key, yajl_type type)
+{
+  const char ** path = {key, 0};
+  yajl_val v = yajl_tree_get(n, path, type);
+  return v;
+}
+
 yajl_val yajl_tree_get(yajl_val n, const char ** path, yajl_type type)
 {
     if (!path) return NULL;

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -452,7 +452,7 @@ yajl_val yajl_tree_parse (const char *input,
     return (ctx.root);
 }
 
-yajl_val yajl_object_get(yajl_val n, const char * key, yajl_type type)
+yajl_val yajl_tree_get(yajl_val n, const char * key, yajl_type type)
 {
   const char ** path = {key, 0};
   yajl_val v = yajl_tree_get(n, path, type);

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -454,7 +454,7 @@ yajl_val yajl_tree_parse (const char *input,
 
 yajl_val yajl_object_get(yajl_val n, const char * key, yajl_type type)
 {
-  const char ** path = {key, 0};
+  const char * path[2] = {key, 0};
   yajl_val v = yajl_tree_get(n, path, type);
   return v;
 }


### PR DESCRIPTION
Hi Lloyd,

I wrote this small function to get around the awkwardness of doing

```
const char ** path = {"some_key", 0}
yajl_tree_get(node, path, yajl_t_any);
```

when I want the value from an immediate object.
Instead I can use

```
yajl_object_get(node, "some_key", yajl_t_any).
```

Martin
