### PR TITLE
encode: add function to completely reset generator state

### DIFF
--- a/src/api/yajl_gen.h
+++ b/src/api/yajl_gen.h
@@ -150,6 +150,12 @@ extern "C" {
      *  intended to enable incremental JSON outputing. */
     YAJL_API void yajl_gen_clear(yajl_gen hand);
 
+    /** completely reset the generator state. Using this function
+     * allows for a single generator instance to be used to generate a
+     * series of JSON values.  This the counterpart to the
+     * yajl_allow_multiple_values parser option. */
+    YAJL_API void yajl_gen_reset(yajl_gen hand);
+
 #ifdef __cplusplus
 }
 #endif    

--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -352,3 +352,11 @@ yajl_gen_clear(yajl_gen g)
 {
     if (g->print == (yajl_print_t)&yajl_buf_append) yajl_buf_clear((yajl_buf)g->ctx);
 }
+
+void
+yajl_gen_reset(yajl_gen g)
+{
+  yajl_gen_clear(g);
+  g->depth = 0;
+  memset(&g->state, 0, sizeof(g->state));
+}


### PR DESCRIPTION
AFAICS, with the current codebase, a new generator instance has to be created for each JSON value.
I'm implementing a protocol based on the exchange of JSON objects. For this use-case it is convenient and also more efficient to re-use the existing generator instance for the entire communication instead of re-allocating a new generator instance for each object/message. I hence implemented a new function to reset the generator state, tentatively named yajl_gen_reset().

From the source code comment added for that function:

```
/** completely reset the generator state. Using this function
 * allows for a single generator instance to be used to generate a
 * series of JSON values.  This the counterpart to the
 * yajl_allow_multiple_values parser option. */
```
