### PR TITLE
Fix include directory in pkg-config template

### DIFF
--- a/src/yajl.pc.cmake
+++ b/src/yajl.pc.cmake
@@ -1,6 +1,6 @@
 prefix=${CMAKE_INSTALL_PREFIX}
 libdir=${dollar}{prefix}/lib${LIB_SUFFIX}
-includedir=${dollar}{prefix}/include/yajl
+includedir=${dollar}{prefix}/include
 
 Name: Yet Another JSON Library
 Description: A Portable JSON parsing and serialization library in ANSI C


### PR DESCRIPTION
The include directory must not include the yajl/ prefix, as
the installed headers rely on the parent to be in the include path.
For example, yajl_parse.h includes <yajl/yajl_common.h>.
