### PR TITLE
Makes 'nmake install' work.

### DIFF
--- a/reformatter/CMakeLists.txt
+++ b/reformatter/CMakeLists.txt
@@ -34,6 +34,4 @@ GET_TARGET_PROPERTY(binPath json_reformat LOCATION)
 ADD_CUSTOM_COMMAND(TARGET json_reformat POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${binPath} ${binDir})
 
-IF (NOT WIN32)
-  INSTALL(TARGETS json_reformat RUNTIME DESTINATION bin)
-ENDIF ()
+INSTALL(TARGETS json_reformat RUNTIME DESTINATION bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,12 +75,13 @@ ENDFOREACH (header ${PUB_HDRS})
 
 INCLUDE_DIRECTORIES(${incDir}/..)
 
-IF(NOT WIN32)
-  # at build time you may specify the cmake variable LIB_SUFFIX to handle
-  # 64-bit systems which use 'lib64'
-  INSTALL(TARGETS yajl LIBRARY DESTINATION lib${LIB_SUFFIX})
-  INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
-  INSTALL(FILES ${PUB_HDRS} DESTINATION include/yajl)
-  INSTALL(FILES ${incDir}/yajl_version.h DESTINATION include/yajl)
-  INSTALL(FILES ${shareDir}/yajl.pc DESTINATION share/pkgconfig)
-ENDIF()
+# at build time you may specify the cmake variable LIB_SUFFIX to handle
+# 64-bit systems which use 'lib64'
+INSTALL(TARGETS yajl
+        RUNTIME DESTINATION lib${LIB_SUFFIX}
+        LIBRARY DESTINATION lib${LIB_SUFFIX}
+        ARCHIVE DESTINATION lib${LIB_SUFFIX})
+INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
+INSTALL(FILES ${PUB_HDRS} DESTINATION include/yajl)
+INSTALL(FILES ${incDir}/yajl_version.h DESTINATION include/yajl)
+INSTALL(FILES ${shareDir}/yajl.pc DESTINATION share/pkgconfig)

--- a/verify/CMakeLists.txt
+++ b/verify/CMakeLists.txt
@@ -34,6 +34,4 @@ GET_TARGET_PROPERTY(binPath json_verify LOCATION)
 ADD_CUSTOM_COMMAND(TARGET json_verify POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${binPath} ${binDir})
 
-IF (NOT WIN32)
-  INSTALL(TARGETS json_verify RUNTIME DESTINATION bin)
-ENDIF ()
+INSTALL(TARGETS json_verify RUNTIME DESTINATION bin)


### PR DESCRIPTION
In BUILDING.WIN32, the following line exists:

```
nmake install
```

This doesn't work because the install targets never get built because of the code:

```
IF(NOT WIN32)
  INSTALL(...)
  ...
ENDIF()
```

in several CMakeLists.txt files. There's no reason to disallow INSTALL on Windows, even if most developers (who use devenv on its own) will never use it.
