### PR TITLE
string length feature

### DIFF
--- a/src/api/yajl_tree.h
+++ b/src/api/yajl_tree.h
@@ -74,7 +74,10 @@ struct yajl_val_s
      * members. */
     union
     {
-        char * string;
+        struct {
+            char * s;
+            size_t len;
+        } string;
         struct {
             long long i; /*< integer value, if representable. */
             double  d;   /*< double value, if representable. */
@@ -158,7 +161,8 @@ YAJL_API yajl_val yajl_tree_get(yajl_val parent, const char ** path, yajl_type t
 
 /** Given a yajl_val_string return a ptr to the bare string it contains,
  *  or NULL if the value is not a string. */
-#define YAJL_GET_STRING(v) (YAJL_IS_STRING(v) ? (v)->u.string : NULL)
+#define YAJL_GET_STRING(v)    (YAJL_IS_STRING(v) ? (v)->u.string.s   : NULL)
+#define YAJL_GET_STRINGLEN(v) (YAJL_IS_STRING(v) ? (v)->u.string.len : 0)
 
 /** Get the string representation of a number.  You should check type first,
  *  perhaps using YAJL_IS_NUMBER */

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -242,8 +242,8 @@ static int context_add_value (context_t *ctx, yajl_val v)
                               "Object key is not a string (%#04x)",
                               v->type);
 
-            ctx->stack->key = v->u.string;
-            v->u.string = NULL;
+            ctx->stack->key = v->u.string.s;
+            v->u.string.s = NULL;
             free(v);
             return (0);
         }
@@ -277,14 +277,15 @@ static int handle_string (void *ctx,
     if (v == NULL)
         RETURN_ERROR ((context_t *) ctx, STATUS_ABORT, "Out of memory");
 
-    v->u.string = malloc (string_length + 1);
-    if (v->u.string == NULL)
+    v->u.string.s = malloc (string_length + 1);
+    if (v->u.string.s == NULL)
     {
         free (v);
         RETURN_ERROR ((context_t *) ctx, STATUS_ABORT, "Out of memory");
     }
-    memcpy(v->u.string, string, string_length);
-    v->u.string[string_length] = 0;
+    memcpy(v->u.string.s, string, string_length);
+    v->u.string.s[string_length] = 0;
+    v->u.string.len = string_length;
 
     return ((context_add_value (ctx, v) == 0) ? STATUS_CONTINUE : STATUS_ABORT);
 }
@@ -480,7 +481,7 @@ void yajl_tree_free (yajl_val v)
 
     if (YAJL_IS_STRING(v))
     {
-        free(v->u.string);
+        free(v->u.string.s);
         free(v);
     }
     else if (YAJL_IS_NUMBER(v))


### PR DESCRIPTION
```
- NOTE: any references to yajl_val->u.string must be changed to
  yajl_val->u.string.s in existing code (should be minimal)

- use YAJL_GET_STRINGLEN(v) macro to get (size_t)length
```

This allows one to use the macros for strings with embedded binary 0s.
