### PR TITLE
Add option yajl_dont_unescape_strings

### DIFF
--- a/src/api/yajl_parse.h
+++ b/src/api/yajl_parse.h
@@ -156,7 +156,14 @@ extern "C" {
          * yajl will enter an error state (premature EOF).  Setting this
          * flag suppresses that check and the corresponding error.
          */
-        yajl_allow_partial_values = 0x10
+        yajl_allow_partial_values = 0x10,
+        /**
+           By default YAJL unescapes strings before passing them to the
+           string callback function. This options disables that behaviour.
+           Some applications might want the string escaped, and without this
+           option their string callback would have to escape the input string.
+         */
+        yajl_dont_unescape_strings = 0x20
     } yajl_option;
 
     /** allow the modification of parser options subsequent to handle

--- a/src/yajl.c
+++ b/src/yajl.c
@@ -91,6 +91,7 @@ yajl_config(yajl_handle h, yajl_option opt, ...)
         case yajl_allow_trailing_garbage:
         case yajl_allow_multiple_values:
         case yajl_allow_partial_values:
+        case yajl_dont_unescape_strings:
             if (va_arg(ap, int)) h->flags |= opt;
             else h->flags &= ~opt;
             break;

--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -246,11 +246,16 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                     break;
                 case yajl_tok_string_with_escapes:
                     if (hand->callbacks && hand->callbacks->yajl_string) {
-                        yajl_buf_clear(hand->decodeBuf);
-                        yajl_string_decode(hand->decodeBuf, buf, bufLen);
-                        _CC_CHK(hand->callbacks->yajl_string(
+                        if (hand->flags & yajl_dont_unescape_strings) {
+                            _CC_CHK(hand->callbacks->yajl_string(hand->ctx,
+                                                                 buf, bufLen));
+                        } else {
+                            yajl_buf_clear(hand->decodeBuf);
+                            yajl_string_decode(hand->decodeBuf, buf, bufLen);
+                            _CC_CHK(hand->callbacks->yajl_string(
                                     hand->ctx, yajl_buf_data(hand->decodeBuf),
                                     yajl_buf_len(hand->decodeBuf)));
+                        }
                     }
                     break;
                 case yajl_tok_bool:

--- a/test/cases/us_string.json
+++ b/test/cases/us_string.json
@@ -1,0 +1,1 @@
+"my escaped \"string\""

--- a/test/cases/us_string.json.gold
+++ b/test/cases/us_string.json.gold
@@ -1,0 +1,2 @@
+string: 'my escaped \"string\"'
+memory leaks:	0

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -41,6 +41,7 @@ for file in cases/*.json ; do
   allowGarbage=""
   allowMultiple=""
   allowPartials=""
+  passEscapedStrings=""
 
   # if the filename starts with dc_, we disallow comments for this test
   case $(basename $file) in
@@ -55,7 +56,9 @@ for file in cases/*.json ; do
      ;;
     ap_*)
      allowPartials="-p ";
-    ;;
+     ;;
+    us_*)
+     passEscapedStrings="-e ";
   esac
   fileShort=`basename $file`
   testName=`echo $fileShort | sed -e 's/\.json$//'`
@@ -67,7 +70,7 @@ for file in cases/*.json ; do
   # ${ECHO} -n "$testBinShort $allowPartials$allowComments$allowGarbage$allowMultiple-b $iter < $fileShort > ${fileShort}.test : "
   # parse with a read buffer size ranging from 1-31 to stress stream parsing
   while [ $iter -lt 32  ] && [ $success = "SUCCESS" ] ; do
-    $testBin $allowPartials $allowComments $allowGarbage $allowMultiple -b $iter < $file > ${file}.test  2>&1
+    $testBin $allowPartials $allowComments $allowGarbage $allowMultiple $passEscapedStrings -b $iter < $file > ${file}.test  2>&1
     diff ${DIFF_FLAGS} ${file}.gold ${file}.test > ${file}.out
     if [ $? -eq 0 ] ; then
       if [ $iter -eq 31 ] ; then : $(( testsSucceeded += 1)) ; fi

--- a/test/yajl_test.c
+++ b/test/yajl_test.c
@@ -219,6 +219,8 @@ main(int argc, char ** argv)
             yajl_config(hand, yajl_allow_multiple_values, 1);
         } else if (!strcmp("-p", argv[i])) {
             yajl_config(hand, yajl_allow_partial_values, 1);
+        } else if (!strcmp("-e", argv[i])) {
+            yajl_config(hand, yajl_dont_unescape_strings, 1);
         } else {
             fprintf(stderr, "invalid command line option: '%s'\n",
                     argv[i]);


### PR DESCRIPTION
This options allows applications to receive unescaped strings
in their string callback. For such applications, this avoids
having them to escape the string in the string callback, which
saves some CPU/memory.
