### PR TITLE
NULL-terminate strings from yajl_parse

### DIFF
--- a/src/yajl_lex.c
+++ b/src/yajl_lex.c
@@ -668,6 +668,10 @@ yajl_lex_lex(yajl_lexer lexer, const unsigned char * jsonText,
         assert(*outLen >= 2);
         (*outBuf)++;
         *outLen -= 2; 
+
+        /* overwrite the closing quote with a NULL
+         * XXX: casting away const-ness, perhaps a bad idea? */
+        ((unsigned char *) (*outBuf))[*outLen] = '\0';
     }
 
 

--- a/test/yajl_test.c
+++ b/test/yajl_test.c
@@ -94,7 +94,12 @@ static int test_yajl_string(void *ctx, const unsigned char * stringVal,
 {
     printf("string: '");
     fwrite(stringVal, 1, stringLen, stdout);
-    printf("'\n");
+
+    if (!stringVal[stringLen])
+        printf("'\n");
+    else
+        printf(" (NOT NULL TERMINATED)'\n");
+
     return 1;
 }
 


### PR DESCRIPTION
Strings are not NULL-terminated because yajl returns pointers into our input JSON text where it can, but since JSON strings are enclosed in quotes anyway, we can just clobber the closing quote with a NULL.

yajl_test is also modified to check that strings are NULL-terminated.
