### PR TITLE
Build fix for NetBSD and other systems where /bin/sh isn't bash

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/sh 
 
 ECHO=`which echo`
 
@@ -70,19 +70,19 @@ for file in cases/*.json ; do
     $testBin $allowPartials $allowComments $allowGarbage $allowMultiple -b $iter < $file > ${file}.test  2>&1
     diff ${DIFF_FLAGS} ${file}.gold ${file}.test > ${file}.out
     if [ $? -eq 0 ] ; then
-      if [ $iter -eq 31 ] ; then : $(( testsSucceeded += 1)) ; fi
+      if [ $iter -eq 31 ] ; then testsSucceeded=$(( $testsSucceeded + 1 )) ; fi
     else
       success="FAILURE"
       iter=32
       ${ECHO}
       cat ${file}.out
     fi
-    : $(( iter += 1 ))
+    iter=$(( iter + 1 ))
     rm ${file}.test ${file}.out
   done
 
   ${ECHO} $success
-  : $(( testsTotal += 1 ))
+  testsTotal=$(( testsTotal + 1 ))
 done
 
 ${ECHO} $testsSucceeded/$testsTotal tests successful


### PR DESCRIPTION
This fixes a build failure on NetBSD. test/run_tests.sh runs under /bin/sh but contains some bash-isms, particularly the way arithmetic is done. It fails on systems where /bin/sh isn't bash or a similar-enough shell.

I changed the #! line to /bin/bash. I could have converted the bash-isms instead, but I figured that it would be more likely to keep working in the future if users run the script under the same shell that's used to develop it.
