### PR TITLE
json_reformat should link against libm

### DIFF
--- a/reformatter/CMakeLists.txt
+++ b/reformatter/CMakeLists.txt
@@ -26,7 +26,7 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
 
 ADD_EXECUTABLE(json_reformat ${SRCS})
 
-TARGET_LINK_LIBRARIES(json_reformat yajl_s)
+TARGET_LINK_LIBRARIES(json_reformat m yajl_s)
 
 # copy the binary into the output directory
 GET_TARGET_PROPERTY(binPath json_reformat LOCATION)


### PR DESCRIPTION
This is specific to qnx.

build error with qnx6.5.0

../yajl-2.0.1/lib/libyajl_s.a(yajl_gen.c.obj): In function yajl_gen_double':
yajl_gen.c:(.text+0x5b9): undefined reference to_DclassBuilding C object example/CMakeFiles/parse_config.dir/parse_config.c.obj
'
yajl_gen.c:(.text+0x5cf): undefined reference to `_Dclass'
cc: /opt/qnx650/host/linux/x86/usr/bin/ntox86-ld error 1
make[2]: **\* [reformatter/json_reformat] Error 1

any platform that links does not link libm while linking libstdc

http://community.qnx.com/sf/discussion/do/listPosts/projects.toolchain/discussion.core_development_tools.topc10811?_pagenum=2
