### PR TITLE
Allow resetting of the generator state in the event of error

### DIFF
--- a/src/api/yajl_gen.h
+++ b/src/api/yajl_gen.h
@@ -150,6 +150,11 @@ extern "C" {
      *  intended to enable incremental JSON outputing. */
     YAJL_API void yajl_gen_clear(yajl_gen hand);
 
+    /** clear yajl's output buffer and reset generator state, but do not
+     *  clear options. this will roll the state back to just before generation
+     *  began */
+    YAJL_API void yajl_gen_reset(yajl_gen hand);
+
 #ifdef __cplusplus
 }
 #endif    

--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -352,3 +352,11 @@ yajl_gen_clear(yajl_gen g)
 {
     if (g->print == (yajl_print_t)&yajl_buf_append) yajl_buf_clear((yajl_buf)g->ctx);
 }
+
+void
+yajl_gen_reset(yajl_gen g)
+{
+    yajl_gen_clear(g);
+    g->depth=0;
+    memset(g->state,0,sizeof(g->state));
+}


### PR DESCRIPTION
This commit adds the ability to reset the generator state back to clean, which is good enough for me. I thought about adding a state save feature to allow rolling back, but this is sufficient for my needs and does not require free/alloc/reconfiguring to get back to a known good state.
