### PR TITLE
replace ./configure's superfluous dependence on ruby with /bin/sh

### DIFF
--- a/configure
+++ b/configure
@@ -16,7 +16,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 prefix="/usr/local"
-if [ "$1" == "--help" ]
+if [ "$1" = "--help" ]
 then
     cat <<EOS
 Usage: configure [options]
@@ -25,7 +25,7 @@ Usage: configure [options]
 EOS
     exit 0
 fi
-if [ "$1" == "-p" ]; then
+if [ "$1" = "-p" ]; then
     if [ "$#" != 2 ]; then
         ./configure.sh --help
         exit 1


### PR DESCRIPTION
this should work on a wider array of machines that are older or in more restricted environments that do not have ruby installed. it's been tested on CentOS and Ubuntu and works with either bash or dash as /bin/sh
