### PR TITLE
Fix build on Windows/Cygwin.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,11 @@ INCLUDE_DIRECTORIES(${incDir}/..)
 IF(NOT WIN32)
   # at build time you may specify the cmake variable LIB_SUFFIX to handle
   # 64-bit systems which use 'lib64'
-  INSTALL(TARGETS yajl LIBRARY DESTINATION lib${LIB_SUFFIX})
+  IF(CYGWIN)
+    INSTALL(TARGETS yajl RUNTIME DESTINATION bin)
+  ELSE()
+    INSTALL(TARGETS yajl LIBRARY DESTINATION lib${LIB_SUFFIX})
+  ENDIF()
   INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
   INSTALL(FILES ${PUB_HDRS} DESTINATION include/yajl)
   INSTALL(FILES ${incDir}/yajl_version.h DESTINATION include/yajl)


### PR DESCRIPTION
New versions of CMake do not define WIN32 variable for Cygwin builds.
As result install rule from src/CMakeLists.txt doesn't find destination
path for RUNTIME (dlls are RUNTIME not LIBRARY).

Fix adds check for IF(CYGWIN).
