### PR TITLE
Fixed DECREMENT macro to return a yajl_gen_status as promised by usage

### DIFF
--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -172,7 +172,7 @@ yajl_gen_free(yajl_gen g)
     if (++(g->depth) >= YAJL_MAX_DEPTH) return yajl_max_depth_exceeded;
 
 #define DECREMENT_DEPTH \
-  if (--(g->depth) >= YAJL_MAX_DEPTH) return yajl_gen_error;
+  if (--(g->depth) >= YAJL_MAX_DEPTH) return yajl_max_depth_exceeded;
 
 #define APPENDED_ATOM \
     switch (g->state[g->depth]) {                   \


### PR DESCRIPTION
Hi Lloyd. 

Clang was complaining about DECREMENT_DEPTH returning yajl_gen_error and, given INCREMENT_DEPTH returned yajl_max_depth_exceeded, that seemed right here.
