### PR TITLE
Added yajl_is_terminal function. This function can be used to determine ...

### DIFF
--- a/src/api/yajl_parse.h
+++ b/src/api/yajl_parse.h
@@ -219,6 +219,9 @@ extern "C" {
     /** free an error returned from yajl_get_error */
     YAJL_API void yajl_free_error(yajl_handle hand, unsigned char * str);
 
+    /** Returns 1 if the yajl_handle is in a terminal state. 0 otherwise */
+    YAJL_API int yajl_is_terminal(yajl_handle hand);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/yajl.c
+++ b/src/yajl.c
@@ -172,4 +172,20 @@ yajl_free_error(yajl_handle hand, unsigned char * str)
     YA_FREE(&(hand->alloc), str);
 }
 
+int
+yajl_is_terminal(yajl_handle hand)
+{
+    yajl_state;
+    if (!hand) return 0;
+
+    switch (yajl_bs_current(hand->stateStack)) {
+        case yajl_state_parse_complete:
+        case yajl_state_parse_error:
+        case yajl_state_lexical_error:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
 /* XXX: add utility routines to parse from file */


### PR DESCRIPTION
...if yajl expects more input.

This allows us to exit early when parsing input in chunks in the following cases:
- when an error is discovered
- if yajl_allow_trailing_garbage is set and a complete document has been parsed
