### PR TITLE
mingw build fixes for yajl_gen

### DIFF
--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 typedef enum {
     yajl_gen_start,
@@ -210,7 +211,11 @@ yajl_gen_integer(yajl_gen g, long long int number)
 {
     char i[32];
     ENSURE_VALID_STATE; ENSURE_NOT_KEY; INSERT_SEP; INSERT_WHITESPACE;
+#ifdef _WIN32
+    sprintf(i, "%" PRId64, (int64_t) number);
+#else
     sprintf(i, "%lld", number);
+#endif
     g->print(g->ctx, i, (unsigned int)strlen(i));
     APPENDED_ATOM;
     FINAL_NEWLINE;
@@ -219,8 +224,12 @@ yajl_gen_integer(yajl_gen g, long long int number)
 
 #if defined(_WIN32) || defined(WIN32)
 #include <float.h>
+#ifndef isnan
 #define isnan _isnan
+#endif
+#ifndef isinf
 #define isinf !_finite
+#endif
 #endif
 
 yajl_gen_status


### PR DESCRIPTION
Win32 doesn't have a `sprintf()` format specification for `long long int`, so on these platforms (32 and 64) we cast the int to `int64_t` and use `PRId64` for the format string.

Also, MinGW already has isnan and isinf defined, so I've put guards around those lines.

For clarification, I'm cross-compiling for win32 and win64 targets from a 64-bit Linux machine.
