### PR TITLE
Dynamically link reformatter / verify tools

### DIFF
--- a/reformatter/CMakeLists.txt
+++ b/reformatter/CMakeLists.txt
@@ -26,7 +26,7 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
 
 ADD_EXECUTABLE(json_reformat ${SRCS})
 
-TARGET_LINK_LIBRARIES(json_reformat yajl_s)
+TARGET_LINK_LIBRARIES(json_reformat yajl)
 
 # In some environments, we must explicitly link libm (like qnx,
 # thanks @shahbag)

--- a/verify/CMakeLists.txt
+++ b/verify/CMakeLists.txt
@@ -26,7 +26,7 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
 
 ADD_EXECUTABLE(json_verify ${SRCS})
 
-TARGET_LINK_LIBRARIES(json_verify yajl_s)
+TARGET_LINK_LIBRARIES(json_verify yajl)
 
 # copy in the binary
 GET_TARGET_PROPERTY(binPath json_verify LOCATION)


### PR DESCRIPTION
Although the json_reformatter and json_verify tools are using
ELF dynamic linking, they were being statically linked to the
yajl.so library. This needlessly wastes disk space.

Signed-off-by: Daniel P. Berrange berrange@redhat.com
