### PR TITLE
Fix paths in run_tests.sh helper scripts

### DIFF
--- a/test/api/run_tests.sh
+++ b/test/api/run_tests.sh
@@ -5,7 +5,7 @@ echo Running api tests:
 tests=0
 passed=0
 
-for file in `ls`; do
+for file in `ls ../../build/test/api`; do
     [ ! -x $file -o -d $file ] && continue
     tests=`expr 1 + $tests`
     printf " test(%s): " $file

--- a/test/parsing/run_tests.sh
+++ b/test/parsing/run_tests.sh
@@ -16,11 +16,11 @@ fi
 # find test binary on both platforms.  allow the caller to force a
 # particular test binary (useful for non-cmake build systems).
 if [ -z "$testBin" ]; then
-    testBin="../build/test/parsing/Release/yajl_test.exe"
+    testBin="../../build/test/parsing/Release/yajl_test.exe"
     if [ ! -x $testBin ] ; then
-        testBin="../build/test/parsing/Debug/yajl_test.exe"
+        testBin="../../build/test/parsing/Debug/yajl_test.exe"
         if [ ! -x $testBin ] ; then
-            testBin="../build/test/parsing/yajl_test"
+            testBin="../../build/test/parsing/yajl_test"
             if [  ! -x $testBin ] ; then
                 ${ECHO} "cannot execute test binary: '$testBin'"
                 exit 1;


### PR DESCRIPTION
When test/parsing/run_tests.sh was moved down a level from
its original location test/run_tests.sh, the paths it uses
were not updated. It is trying to access ../build/test
instead of ../../build/test.

The newly added test/api/run_tests.sh was not even looking
in the build directory, instead looking for executable files
in the current directory. This made it find itself, causing
it to exec itself resulting a fork bomb.

Signed-off-by: Daniel P. Berrange berrange@redhat.com
