### PR TITLE
The 'yajl/' path component is used by header files

### DIFF
--- a/src/yajl.pc.cmake
+++ b/src/yajl.pc.cmake
@@ -1,6 +1,6 @@
 prefix=${CMAKE_INSTALL_PREFIX}
 libdir=${dollar}{prefix}/lib${LIB_SUFFIX}
-includedir=${dollar}{prefix}/include/yajl
+includedir=${dollar}{prefix}/include
 
 Name: Yet Another JSON Library
 Description: A Portable JSON parsing and serialization library in ANSI C


### PR DESCRIPTION
We do not need that in pkg-config's includedir.
