### PR TITLE
api/yajl_parse.h: Document how NULL callbacks are treated.

### DIFF
--- a/src/api/yajl_parse.h
+++ b/src/api/yajl_parse.h
@@ -53,6 +53,9 @@ extern "C" {
      *  pointer, this is a void * that is passed into the yajl_parse
      *  function which the client code may use to pass around context.
      *
+     *  Members of the struct may be NULL to signify "no callback set".
+     *  Parsing will continue after matching elements are encountered.
+     *
      *  All callbacks return an integer.  If non-zero, the parse will
      *  continue.  If zero, the parse will be canceled and
      *  yajl_status_client_canceled will be returned from the parse.


### PR DESCRIPTION
Hi Lloyd,

here's a simple documentation fix because I had to read the source to figure out the behavior for the "callback is `NULL`" case.

Best regards,
—octo
