### PR TITLE
remove ruby from BUILDING

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -4,8 +4,7 @@ Short story (If you already have ruby and cmake):
 
 When things go wrong:
 
-attain CMake (http://www.cmake.org) and ruby (http://ruby-lang.org) and
-try again.
+attain CMake (http://www.cmake.org) and try again.
 
 OR, attain CMake and build by hand:
 


### PR DESCRIPTION
It doesn't appear to be a dependency anymore as of: https://github.com/lloyd/yajl/commit/a0229579a661abd1e6ae86d5094cdcd7f0793d72
