### PR TITLE
fix: check allocation issues so that the library user can gracefully errors

### DIFF
--- a/src/yajl_buf.c
+++ b/src/yajl_buf.c
@@ -30,16 +30,19 @@ struct yajl_buf_t {
 };
 
 static
-void yajl_buf_ensure_available(yajl_buf buf, size_t want)
+int yajl_buf_ensure_available(yajl_buf buf, size_t want)
 {
     size_t need;
-    
+
     assert(buf != NULL);
 
     /* first call */
     if (buf->data == NULL) {
         buf->len = YAJL_BUF_INIT_SIZE;
         buf->data = (unsigned char *) YA_MALLOC(buf->alloc, buf->len);
+        if (! buf->data)
+          return -1;
+
         buf->data[0] = 0;
     }
 
@@ -48,14 +51,23 @@ void yajl_buf_ensure_available(yajl_buf buf, size_t want)
     while (want >= (need - buf->used)) need <<= 1;
 
     if (need != buf->len) {
-        buf->data = (unsigned char *) YA_REALLOC(buf->alloc, buf->data, need);
+        void *tmpdata = YA_REALLOC(buf->alloc, buf->data, need);
+        if (! tmpdata)
+            return -1;
+
+        buf->data = tmpdata;
         buf->len = need;
     }
+
+    return 0;
 }
 
 yajl_buf yajl_buf_alloc(yajl_alloc_funcs * alloc)
 {
     yajl_buf b = YA_MALLOC(alloc, sizeof(struct yajl_buf_t));
+    if (! b)
+        return NULL;
+
     memset((void *) b, 0, sizeof(struct yajl_buf_t));
     b->alloc = alloc;
     return b;
@@ -68,15 +80,19 @@ void yajl_buf_free(yajl_buf buf)
     YA_FREE(buf->alloc, buf);
 }
 
-void yajl_buf_append(yajl_buf buf, const void * data, size_t len)
+int yajl_buf_append(yajl_buf buf, const void * data, size_t len)
 {
-    yajl_buf_ensure_available(buf, len);
+    if (-1 == yajl_buf_ensure_available(buf, len))
+        return -1;
+
     if (len > 0) {
         assert(data != NULL);
         memcpy(buf->data + buf->used, data, len);
         buf->used += len;
         buf->data[buf->used] = 0;
     }
+
+    return 0;
 }
 
 void yajl_buf_clear(yajl_buf buf)

--- a/src/yajl_buf.h
+++ b/src/yajl_buf.h
@@ -40,7 +40,7 @@ yajl_buf yajl_buf_alloc(yajl_alloc_funcs * alloc);
 void yajl_buf_free(yajl_buf buf);
 
 /* append a number of bytes to the buffer */
-void yajl_buf_append(yajl_buf buf, const void * data, size_t len);
+int yajl_buf_append(yajl_buf buf, const void * data, size_t len);
 
 /* empty the buffer */
 void yajl_buf_clear(yajl_buf buf);

--- a/src/yajl_encode.c
+++ b/src/yajl_encode.c
@@ -113,17 +113,19 @@ static void Utf32toUtf8(unsigned int codepoint, char * utf8Buf)
     }
 }
 
-void yajl_string_decode(yajl_buf buf, const unsigned char * str,
-                        size_t len)
+int yajl_string_decode(yajl_buf buf, const unsigned char * str,
+                       size_t len)
 {
     size_t beg = 0;
-    size_t end = 0;    
+    size_t end = 0;
 
     while (end < len) {
         if (str[end] == '\\') {
             char utf8Buf[5];
             const char * unescaped = "?";
-            yajl_buf_append(buf, str + beg, end - beg);
+            if (-1 == yajl_buf_append(buf, str + beg, end - beg))
+                goto err;
+
             switch (str[++end]) {
                 case 'r': unescaped = "\r"; break;
                 case 'n': unescaped = "\n"; break;
@@ -144,8 +146,8 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                             unsigned int surrogate = 0;
                             hexToDigit(&surrogate, str + end + 2);
                             codepoint =
-                                (((codepoint & 0x3F) << 10) | 
-                                 ((((codepoint >> 6) & 0xF) + 1) << 16) | 
+                                (((codepoint & 0x3F) << 10) |
+                                 ((((codepoint >> 6) & 0xF) + 1) << 16) |
                                  (surrogate & 0x3FF));
                             end += 5;
                         } else {
@@ -153,12 +155,14 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                             break;
                         }
                     }
-                    
+
                     Utf32toUtf8(codepoint, utf8Buf);
                     unescaped = utf8Buf;
 
                     if (codepoint == 0) {
-                        yajl_buf_append(buf, unescaped, 1);
+                        if (-1 == yajl_buf_append(buf, unescaped, 1))
+                            goto err;
+
                         beg = ++end;
                         continue;
                     }
@@ -168,13 +172,22 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                 default:
                     assert("this should never happen" == NULL);
             }
-            yajl_buf_append(buf, unescaped, (unsigned int)strlen(unescaped));
+            if (-1 == yajl_buf_append(buf, unescaped,
+                                      (unsigned int)strlen(unescaped)))
+                goto err;
+
             beg = ++end;
         } else {
             end++;
         }
     }
-    yajl_buf_append(buf, str + beg, end - beg);
+
+    if (-1 == yajl_buf_append(buf, str + beg, end - beg))
+      goto err;
+
+    return 0;
+ err:
+    return -1;
 }
 
 #define ADV_PTR s++; if (!(len--)) return 0;

--- a/src/yajl_encode.h
+++ b/src/yajl_encode.h
@@ -26,8 +26,8 @@ void yajl_string_encode(const yajl_print_t printer,
                         size_t length,
                         int escape_solidus);
 
-void yajl_string_decode(yajl_buf buf, const unsigned char * str,
-                        size_t length);
+int yajl_string_decode(yajl_buf buf, const unsigned char * str,
+                       size_t length);
 
 int yajl_string_validate_utf8(const unsigned char * s, size_t len);
 

--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -265,6 +265,7 @@ yajl_gen_string(yajl_gen g, const unsigned char * str,
     ENSURE_VALID_STATE; INSERT_SEP; INSERT_WHITESPACE;
     g->print(g->ctx, "\"", 1);
     yajl_string_encode(g->print, g->ctx, str, len, g->flags & yajl_gen_escape_solidus);
+
     g->print(g->ctx, "\"", 1);
     APPENDED_ATOM;
     FINAL_NEWLINE;

--- a/src/yajl_lex.c
+++ b/src/yajl_lex.c
@@ -649,7 +649,13 @@ yajl_lex_lex(yajl_lexer lexer, const unsigned char * jsonText,
     if (tok == yajl_tok_eof || lexer->bufInUse) {
         if (!lexer->bufInUse) yajl_buf_clear(lexer->buf);
         lexer->bufInUse = 1;
-        yajl_buf_append(lexer->buf, jsonText + startOffset, *offset - startOffset);
+        if (-1 == yajl_buf_append(lexer->buf, jsonText + startOffset,
+                                  *offset - startOffset)) {
+            *outBuf = NULL;
+            *outLen = 0;
+            return yajl_tok_eof;
+        }
+
         lexer->bufOff = 0;
 
         if (tok != yajl_tok_eof) {

--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -247,7 +247,10 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                 case yajl_tok_string_with_escapes:
                     if (hand->callbacks && hand->callbacks->yajl_string) {
                         yajl_buf_clear(hand->decodeBuf);
-                        yajl_string_decode(hand->decodeBuf, buf, bufLen);
+                        if (-1 == yajl_string_decode(hand->decodeBuf, buf,
+                                                     bufLen))
+                            goto err;
+
                         _CC_CHK(hand->callbacks->yajl_string(
                                     hand->ctx, yajl_buf_data(hand->decodeBuf),
                                     yajl_buf_len(hand->decodeBuf)));
@@ -309,7 +312,10 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                         } else if (hand->callbacks->yajl_double) {
                             double d = 0.0;
                             yajl_buf_clear(hand->decodeBuf);
-                            yajl_buf_append(hand->decodeBuf, buf, bufLen);
+                            if (-1 == yajl_buf_append(hand->decodeBuf, buf,
+                                                      bufLen))
+                                return yajl_status_error;
+
                             buf = yajl_buf_data(hand->decodeBuf);
                             errno = 0;
                             d = strtod((char *) buf, NULL);
@@ -389,7 +395,10 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                 case yajl_tok_string_with_escapes:
                     if (hand->callbacks && hand->callbacks->yajl_map_key) {
                         yajl_buf_clear(hand->decodeBuf);
-                        yajl_string_decode(hand->decodeBuf, buf, bufLen);
+                        if (-1 == yajl_string_decode(hand->decodeBuf, buf,
+                                                     bufLen))
+                            goto err;
+
                         buf = yajl_buf_data(hand->decodeBuf);
                         bufLen = yajl_buf_len(hand->decodeBuf);
                     }
@@ -492,7 +501,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
         }
     }
 
-    abort();
+ err:
     return yajl_status_error;
 }
 


### PR DESCRIPTION
When an allocation fails deep inside yajl_parse(), it simply crashes the library.   The user should be notified by an error code, instead.