### PR TITLE
Fixed configure script to accept "-h" and "--prefix".

### DIFF
--- a/configure
+++ b/configure
@@ -15,19 +15,18 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 prefix="/usr/local"
+usage="Usage: configure [options]
+    -p, --prefix PATH                Set installation prefix
+    -h, --help                       Output usage summary"
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then
-    cat <<EOS
-Usage: configure [options]
-    -p, --prefix PATH                Set installation prefix
-    -h, --help                       Output usage summary
-EOS
+    echo "$usage"
     exit 0
 fi
 if [ "$1" = "-p" ] || [ "$1" = "--prefix" ]
 then
     if [ "$#" != 2 ]; then
-        ./configure.sh --help
+        echo "$usage"
         exit 1
     fi
     prefix="$2"

--- a/configure
+++ b/configure
@@ -15,7 +15,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 prefix="/usr/local"
-if [ "$1" = "--help" ]
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then
     cat <<EOS
 Usage: configure [options]
@@ -24,7 +24,8 @@ Usage: configure [options]
 EOS
     exit 0
 fi
-if [ "$1" = "-p" ]; then
+if [ "$1" = "-p" ] || [ "$1" = "--prefix" ]
+then
     if [ "$#" != 2 ]; then
         ./configure.sh --help
         exit 1


### PR DESCRIPTION
Calling `./configure --prefix PATH` ignored the option (and PATH).
Same with `./configure -h`.
Missing `PATH` (or additional argument) called `./configure --help` which showed the error:
```
# ./configure -p
./configure: 29: ./configure: ./configure.sh: not found
```

Fixed configure script to accept `-h` (in addition to `--help`) and `--prefix PATH` (in addition to `-p PATH`) as stated in usage/help of the script. Also put usage/help into a variable and echoed when arguments were incorrect, to avoid error listed above.
