### PR TITLE
Install pkg-config files correctly.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,4 +84,4 @@ INSTALL(TARGETS yajl
 INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
 INSTALL(FILES ${PUB_HDRS} DESTINATION include/yajl)
 INSTALL(FILES ${incDir}/yajl_version.h DESTINATION include/yajl)
-INSTALL(FILES ${shareDir}/yajl.pc DESTINATION share/pkgconfig)
+INSTALL(FILES ${shareDir}/yajl.pc DESTINATION lib${LIB_SUFFIX}/pkgconfig)


### PR DESCRIPTION
Typically the pkg-config files should go into lib/ and be
prefix-prepended so that cross-compiling works as expected. This
change makes installed .pc files consistent with most other packages.