### PR TITLE
change the api yajl_tree_parse to yajl_tree_nparse and add a macro fo…

### DIFF
--- a/src/api/yajl_tree.h
+++ b/src/api/yajl_tree.h
@@ -102,8 +102,8 @@ struct yajl_val_s
  * Parses an null-terminated string containing JSON data and returns a pointer
  * to the top-level value (root of the parse tree).
  *
- * \param input              Pointer to a null-terminated utf8 string containing
- *                           JSON data.
+ * \param input              Pointer to a utf8 string containing JSON data.
+ * \param size               Size of the JSON string
  * \param error_buffer       Pointer to a buffer in which an error message will
  *                           be stored if \em yajl_tree_parse fails, or
  *                           \c NULL. The buffer will be initialized before
@@ -118,8 +118,10 @@ struct yajl_val_s
  * null terminated message describing the error in more detail is stored in
  * \em error_buffer if it is not \c NULL.
  */
-YAJL_API yajl_val yajl_tree_parse (const char *input,
+YAJL_API yajl_val yajl_tree_nparse (const char *input, size_t size,
                                    char *error_buffer, size_t error_buffer_size);
+#define yajl_tree_parse(input, error_buffer, error_buffer_size) \
+    yajl_tree_nparse((input), strlen(input), (error_buffer), (error_buffer_size))
 
 
 /**

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -400,7 +400,7 @@ static int handle_null (void *ctx)
 /*
  * Public functions
  */
-yajl_val yajl_tree_parse (const char *input,
+yajl_val yajl_tree_nparse (const char *input, size_t size,
                           char *error_buffer, size_t error_buffer_size)
 {
     static const yajl_callbacks callbacks =
@@ -434,13 +434,13 @@ yajl_val yajl_tree_parse (const char *input,
 
     status = yajl_parse(handle,
                         (unsigned char *) input,
-                        strlen (input));
+                       size); 
     status = yajl_complete_parse (handle);
     if (status != yajl_status_ok) {
         if (error_buffer != NULL && error_buffer_size > 0) {
                internal_err_str = (char *) yajl_get_error(handle, 1,
                      (const unsigned char *) input,
-                     strlen(input));
+                     size);
              snprintf(error_buffer, error_buffer_size, "%s", internal_err_str);
              YA_FREE(&(handle->alloc), internal_err_str);
         }


### PR DESCRIPTION
…r the origin one

	yajl_tree_nparse dose not need the input string to be null-terminated.