### PR TITLE
Memory leak in yajl_tree_parse

### DIFF
--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -444,6 +444,9 @@ yajl_val yajl_tree_parse (const char *input,
              snprintf(error_buffer, error_buffer_size, "%s", internal_err_str);
              YA_FREE(&(handle->alloc), internal_err_str);
         }
+        while (ctx.stack) {
+            yajl_tree_free(context_pop(&ctx));
+        }
         yajl_free (handle);
         return NULL;
     }


### PR DESCRIPTION
The yajl_tree_parse function does not deallocate ctx.stack when yajl_complete_parse returns an error condition, resulting in a memory leak.  The solution is to pop all elements off the stack and yajl_tree_free their values.
