### PR TITLE
add ability for yajl handle to reset

### DIFF
--- a/src/api/yajl_parse.h
+++ b/src/api/yajl_parse.h
@@ -101,7 +101,7 @@ extern "C" {
      *                    are encountered in the input text.  May be NULL,
      *                    which is only useful for validation.
      *  \param afs        memory allocation functions, may be NULL for to use
-     *                    C runtime library routines (malloc and friends) 
+     *                    C runtime library routines (malloc and friends)
      *  \param ctx        a context pointer that will be passed to callbacks.
      */
     YAJL_API yajl_handle yajl_alloc(const yajl_callbacks * callbacks,
@@ -167,6 +167,9 @@ extern "C" {
 
     /** free a parser handle */
     YAJL_API void yajl_free(yajl_handle handle);
+
+    /** reset a parser handle */
+    YAJL_API void yajl_reset(yajl_handle handle);
 
     /** Parse some json!
      *  \param hand - a handle to the json parser allocated with yajl_alloc

--- a/src/yajl.c
+++ b/src/yajl.c
@@ -68,7 +68,7 @@ yajl_alloc(const yajl_callbacks * callbacks,
 
     hand->callbacks = callbacks;
     hand->ctx = ctx;
-    hand->lexer = NULL; 
+    hand->lexer = NULL;
     hand->bytesConsumed = 0;
     hand->decodeBuf = yajl_buf_alloc(&(hand->alloc));
     hand->flags	    = 0;
@@ -112,6 +112,17 @@ yajl_free(yajl_handle handle)
         handle->lexer = NULL;
     }
     YA_FREE(&(handle->alloc), handle);
+}
+
+void
+yajl_reset(yajl_handle handle)
+{
+    yajl_bs_reset(handle->stateStack);
+    yajl_bs_push(handle->stateStack, yajl_state_start);
+    yajl_buf_reset(handle->decodeBuf);
+    handle->bytesConsumed = 0;
+    if (handle->lexer != NULL)
+        yajl_lex_reset(handle->lexer);
 }
 
 yajl_status

--- a/src/yajl_buf.c
+++ b/src/yajl_buf.c
@@ -33,7 +33,7 @@ static
 void yajl_buf_ensure_available(yajl_buf buf, size_t want)
 {
     size_t need;
-    
+
     assert(buf != NULL);
 
     /* first call */
@@ -66,6 +66,12 @@ void yajl_buf_free(yajl_buf buf)
     assert(buf != NULL);
     if (buf->data) YA_FREE(buf->alloc, buf->data);
     YA_FREE(buf->alloc, buf);
+}
+
+void yajl_buf_reset(yajl_buf buf)
+{
+    assert(buf != NULL);
+    buf->used = 0;
 }
 
 void yajl_buf_append(yajl_buf buf, const void * data, size_t len)

--- a/src/yajl_buf.h
+++ b/src/yajl_buf.h
@@ -22,7 +22,7 @@
 
 /*
  * Implementation/performance notes.  If this were moved to a header
- * only implementation using #define's where possible we might be 
+ * only implementation using #define's where possible we might be
  * able to sqeeze a little performance out of the guy by killing function
  * call overhead.  YMMV.
  */
@@ -38,6 +38,9 @@ yajl_buf yajl_buf_alloc(yajl_alloc_funcs * alloc);
 
 /* free the buffer */
 void yajl_buf_free(yajl_buf buf);
+
+/* reset the buffer */
+void yajl_buf_reset(yajl_buf buf);
 
 /* append a number of bytes to the buffer */
 void yajl_buf_append(yajl_buf buf, const void * data, size_t len);

--- a/src/yajl_bytestack.h
+++ b/src/yajl_bytestack.h
@@ -47,6 +47,8 @@ typedef struct yajl_bytestack_t
 #define yajl_bs_free(obs)                 \
     if ((obs).stack) (obs).yaf->free((obs).yaf->ctx, (obs).stack);
 
+#define yajl_bs_reset(obs) (obs).used = 0;
+
 #define yajl_bs_current(obs)               \
     (assert((obs).used > 0), (obs).stack[(obs).used - 1])
 

--- a/src/yajl_lex.c
+++ b/src/yajl_lex.c
@@ -121,6 +121,17 @@ yajl_lex_free(yajl_lexer lxr)
     return;
 }
 
+void
+yajl_lex_reset(yajl_lexer lxr)
+{
+    yajl_buf_reset(lxr->buf);
+    lxr->lineOff = 0;
+    lxr->charOff = 0;
+    lxr->bufOff = 0;
+    lxr->bufInUse = 0;
+    lxr->error = yajl_lex_e_ok;
+}
+
 /* a lookup table which lets us quickly determine three things:
  * VEC - valid escaped control char
  * note.  the solidus '/' may be escaped or not.

--- a/src/yajl_lex.h
+++ b/src/yajl_lex.h
@@ -53,6 +53,8 @@ yajl_lexer yajl_lex_alloc(yajl_alloc_funcs * alloc,
 
 void yajl_lex_free(yajl_lexer lexer);
 
+void yajl_lex_reset(yajl_lexer lexer);
+
 /**
  * run/continue a lex. "offset" is an input/output parameter.
  * It should be initialized to zero for a


### PR DESCRIPTION
The main purpose of adding a reset ability is to use the same handle after an error or client cancellation without reallocation. 

I haven't added tests yet, I was just going to add a new test executable under `test/api`.

Adds public api function:

``` c
void yajl_reset(yajl_handle handle)
```

Adds internal functions:

``` c
void yajl_bs_reset(yajl_bytestack obs);
void yajl_buf_reset(yajl_buf buf);
void yajl_lex_reset(yajl_lexer lxr);
```
