### PR TITLE
remove unneeded parsing of plus sign when parsing integer

### DIFF
--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -39,7 +39,6 @@ yajl_parse_integer(const unsigned char *number, unsigned int length)
     long sign = 1;
     const unsigned char *pos = number;
     if (*pos == '-') { pos++; sign = -1; }
-    if (*pos == '+') { pos++; }
 
     while (pos < number + length) {
         if ( ret > MAX_VALUE_TO_MULTIPLY ) {


### PR DESCRIPTION
Looking at
https://tools.ietf.org/html/rfc7159
numbers are not allowed to start with a plus sign. 

This patch removes an unneeded parsing of a "+"  in the function

```
long long yajl_parse_integer(const unsigned char *number, unsigned int length)
```
