### PR TITLE
Fix macro redefinition for newer MSVC

### DIFF
--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -217,7 +217,7 @@ yajl_gen_integer(yajl_gen g, long long int number)
     return yajl_gen_status_ok;
 }
 
-#if defined(_WIN32) || defined(WIN32)
+#if defined(_MSC_VER) && _MSC_VER < 1800
 #include <float.h>
 #define isnan _isnan
 #define isinf !_finite


### PR DESCRIPTION
Visual Studio 2013+ have functions like `isnan` defined, so the code should check against `_MSC_VER` to see if the redefinition to `_isnan` is necessary.
