### PR TITLE
Fix pkgconfig file to be relocatable.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,9 +59,8 @@ FILE(MAKE_DIRECTORY ${libDir})
 FILE(MAKE_DIRECTORY ${incDir})
 
 # generate build-time source
-SET(dollar $)
 CONFIGURE_FILE(api/yajl_version.h.cmake ${incDir}/yajl_version.h)
-CONFIGURE_FILE(yajl.pc.cmake ${shareDir}/yajl.pc)
+CONFIGURE_FILE(yajl.pc.cmake ${shareDir}/yajl.pc @ONLY)
 
 # copy public headers to output directory
 FOREACH (header ${PUB_HDRS})

--- a/src/yajl.pc.cmake
+++ b/src/yajl.pc.cmake
@@ -1,6 +1,6 @@
 prefix=${pcfiledir}/../..
 libdir=${prefix}/lib@LIB_SUFFIX@
-includedir=${prefix}/include/yajl
+includedir=${prefix}/include
 
 Name: Yet Another JSON Library
 Description: A Portable JSON parsing and serialization library in ANSI C

--- a/src/yajl.pc.cmake
+++ b/src/yajl.pc.cmake
@@ -1,9 +1,9 @@
-prefix=${CMAKE_INSTALL_PREFIX}
-libdir=${dollar}{prefix}/lib${LIB_SUFFIX}
-includedir=${dollar}{prefix}/include/yajl
+prefix=${pcfiledir}/../..
+libdir=${prefix}/lib@LIB_SUFFIX@
+includedir=${prefix}/include/yajl
 
 Name: Yet Another JSON Library
 Description: A Portable JSON parsing and serialization library in ANSI C
-Version: ${YAJL_MAJOR}.${YAJL_MINOR}.${YAJL_MICRO}
-Cflags: -I${dollar}{includedir}
-Libs: -L${dollar}{libdir} -lyajl
+Version: @YAJL_MAJOR@.@YAJL_MINOR@.@YAJL_MICRO@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lyajl


### PR DESCRIPTION
When using relocatable cross toolchain with yajl included the result can
be copied to different paths and machines. It can be even used from
docker or something similar. However, current modification makes
pkgconfig file for yajl relocatable and independet from the original
package installation path.