### PR TITLE
add va_list overload of `yajl_gen_config`

### DIFF
--- a/src/api/yajl_gen.h
+++ b/src/api/yajl_gen.h
@@ -25,6 +25,7 @@
 #define __YAJL_GEN_H__
 
 #include <stddef.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,6 +107,8 @@ extern "C" {
      *  \returns zero in case of errors, non-zero otherwise
      */
     YAJL_API int yajl_gen_config(yajl_gen g, yajl_gen_option opt, ...);
+    
+    YAJL_API int yajl_gen_config_v(yajl_gen g, yajl_gen_option opt, va_list ap);
 
     /** allocate a generator handle
      *  \param allocFuncs an optional pointer to a structure which allows

--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -47,12 +47,17 @@ struct yajl_gen_t
     yajl_alloc_funcs alloc;
 };
 
-int
-yajl_gen_config(yajl_gen g, yajl_gen_option opt, ...)
-{
-    int rv = 1;
+int yajl_gen_config(yajl_gen g, yajl_gen_option opt, ...) {
     va_list ap;
     va_start(ap, opt);
+    int rv = yajl_gen_config_v(g, opt, ap);
+    va_end(ap);
+    return rv;
+}
+
+int yajl_gen_config_v(yajl_gen g, yajl_gen_option opt, va_list ap)
+{
+    int rv = 1;
 
     switch(opt) {
         case yajl_gen_beautify:
@@ -86,8 +91,6 @@ yajl_gen_config(yajl_gen g, yajl_gen_option opt, ...)
         default:
             rv = 0;
     }
-
-    va_end(ap);
 
     return rv;
 }


### PR DESCRIPTION
This PR add va_list overload of `yajl_gen_config`.

I am using this library from my JSON library in Swift.
Swift has C Interop feature so I use yajl API directly from Swift.

https://github.com/omochi/FineJSON/blob/master/Sources/FineJSON/JSONSerialize.swift

Unfortunately, Swift can not call variadic argument function in C.
This is limitation of interop feature.
But it can handle `va_list` normally.

So I want to add this overload.
