### PR TITLE
cmake: Fix installing pkg-config file into libdir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ ADD_DEFINITIONS(-DYAJL_BUILD)
 # set up some paths
 SET (libDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
 SET (incDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/include/yajl)
-SET (shareDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/share/pkgconfig)
+SET (pcDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib/pkgconfig)
 
 # set the output path for libraries
 SET(LIBRARY_OUTPUT_PATH ${libDir})
@@ -61,7 +61,7 @@ FILE(MAKE_DIRECTORY ${incDir})
 # generate build-time source
 SET(dollar $)
 CONFIGURE_FILE(api/yajl_version.h.cmake ${incDir}/yajl_version.h)
-CONFIGURE_FILE(yajl.pc.cmake ${shareDir}/yajl.pc)
+CONFIGURE_FILE(yajl.pc.cmake ${pcDir}/yajl.pc)
 
 # copy public headers to output directory
 FOREACH (header ${PUB_HDRS})
@@ -84,4 +84,4 @@ INSTALL(TARGETS yajl
 INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
 INSTALL(FILES ${PUB_HDRS} DESTINATION include/yajl)
 INSTALL(FILES ${incDir}/yajl_version.h DESTINATION include/yajl)
-INSTALL(FILES ${shareDir}/yajl.pc DESTINATION share/pkgconfig)
+INSTALL(FILES ${pcDir}/yajl.pc DESTINATION lib${LIB_SUFFIX}/pkgconfig)


### PR DESCRIPTION
Fix the CMake rules to install pkg-config file into lib/pkgconfig
rather than share/pkgconfig.  The former location is correct
for ABI-dependent files such as libraries, while the latter should be
used only for ABI-agnostic resources (data files, executables).

This fixes using yajl on multilib systems where 32-bit and 64-bit
versions of the library are installed separately.  This requires two
separate pkg-config files to be installed along with the libraries
into appropriate libdirs.  When the file was installed into /usr/share,
only one variant was permitted and effectively using the other multilib
variant was broken, breaking other packages.

Original bug report: https://bugs.gentoo.org/677870