### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -21,11 +21,11 @@ NOTE: for 64-bit systems where lib64 is used you can pass the cmake
 
 Alternatively, you can build and install yajl using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install yajl
+1. git clone https://github.com/Microsoft/vcpkg.git
+2. cd vcpkg
+3. ./bootstrap-vcpkg.sh
+4. ./vcpkg integrate install
+5. ./vcpkg install yajl
 
 The yajl port in vcpkg is kept up to date by Microsoft team members and community contributors.
 

--- a/BUILDING
+++ b/BUILDING
@@ -19,5 +19,15 @@ NOTE: for 64-bit systems where lib64 is used you can pass the cmake
       variable LIB_SUFFIX to cause installation into the system's 'lib64'
       directory.
 
+Alternatively, you can build and install yajl using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install yajl
+
+The yajl port in vcpkg is kept up to date by Microsoft team members and community contributors.
+
 best,
 lloyd


### PR DESCRIPTION
yajl is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build yajl, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for yajl and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
