### PR TITLE
fixed utf-8 output corrupted with truncated surrogates pairs

### DIFF
--- a/src/yajl_encode.c
+++ b/src/yajl_encode.c
@@ -139,9 +139,9 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                     end+=3;
                     /* check if this is a surrogate */
                     if ((codepoint & 0xFC00) == 0xD800) {
-                        end++;
-                        if (str[end] == '\\' && str[end + 1] == 'u') {
+                        if (str[end + 1] == '\\' && str[end + 2] == 'u') {
                             unsigned int surrogate = 0;
+                            end++;
                             hexToDigit(&surrogate, str + end + 2);
                             codepoint =
                                 (((codepoint & 0x3F) << 10) | 


### PR DESCRIPTION
Fixed utf-8 output corrupted with truncated surrogates pairs.

As an example, the \uDBFF💀 sequence would produce "?" and then a truncated version of "💀" which would result in invalid-UTF-8.
