### PR TITLE
Fix include path for pkg-config

### DIFF
--- a/src/yajl.pc.cmake
+++ b/src/yajl.pc.cmake
@@ -1,6 +1,6 @@
 prefix=${CMAKE_INSTALL_PREFIX}
 libdir=${dollar}{prefix}/lib${LIB_SUFFIX}
-includedir=${dollar}{prefix}/include/yajl
+includedir=${dollar}{prefix}/include
 
 Name: Yet Another JSON Library
 Description: A Portable JSON parsing and serialization library in ANSI C


### PR DESCRIPTION
yajl headers are supposed to be installed straight into $PREFIX/include/yajl
and they're supposed to be included as <yajl/yajl_something.h>, according to
the documentation.

However, pkg-config returns CFLAGS as $PREFIX/include/yajl and that
breaks build because "#include <yajl/yajl_something.h>" can't find the
header.

This is a problem if $PREFIX is different from /usr or other include
directory that's used implicitly (which is a case on macOS with
homebrew, where every package has its own $PREFIX).