### PR TITLE
Alternative fix for CVE-2022-24795

### DIFF
--- a/src/yajl_buf.c
+++ b/src/yajl_buf.c
@@ -45,7 +45,15 @@ void yajl_buf_ensure_available(yajl_buf buf, size_t want)
 
     need = buf->len;
 
-    while (want >= (need - buf->used)) need <<= 1;
+    while (need > 0 && want >= (need - buf->used)) {
+        /* this eventually "overflows" to zero */
+        need <<= 1;
+    }
+
+    /* overflow */
+    if (need < buf->len) {
+        abort();
+    }
 
     if (need != buf->len) {
         buf->data = (unsigned char *) YA_REALLOC(buf->alloc, buf->data, need);


### PR DESCRIPTION
This is a "hybrid" of https://github.com/lloyd/yajl/pull/240, https://github.com/brianmario/yajl-ruby/pull/211 and https://github.com/robohack/yajl/commit/166b384aec1cf304859d69f03e42c3ab85c34858

Using `abort()` to avoid heap corruption/infinite loop while not adding new requirements for clients of this library and/or complex error handling mechanisms.