### PR TITLE
Fix windows/msvc build by putting gcc specific attribute in a macro

### DIFF
--- a/reformatter/CMakeLists.txt
+++ b/reformatter/CMakeLists.txt
@@ -26,7 +26,7 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
 
 ADD_EXECUTABLE(json_reformat ${SRCS})
 
-TARGET_LINK_LIBRARIES(json_reformat yajl_s)
+TARGET_LINK_LIBRARIES(json_reformat yajl)
 
 # In some environments, we must explicitly link libm (like qnx,
 # thanks @shahbag)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ ADD_DEFINITIONS(-DYAJL_BUILD)
 # set up some paths
 SET (libDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
 SET (incDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/include/yajl)
-SET (shareDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/share/pkgconfig)
+SET (pkgconfigDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib/pkgconfig)
 
 # set the output path for libraries
 SET(LIBRARY_OUTPUT_PATH ${libDir})
@@ -61,7 +61,7 @@ FILE(MAKE_DIRECTORY ${incDir})
 # generate build-time source
 SET(dollar $)
 CONFIGURE_FILE(api/yajl_version.h.cmake ${incDir}/yajl_version.h)
-CONFIGURE_FILE(yajl.pc.cmake ${shareDir}/yajl.pc)
+CONFIGURE_FILE(yajl.pc.cmake ${pkgconfigDir}/yajl.pc)
 
 # copy public headers to output directory
 FOREACH (header ${PUB_HDRS})
@@ -84,4 +84,4 @@ INSTALL(TARGETS yajl
 INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
 INSTALL(FILES ${PUB_HDRS} DESTINATION include/yajl)
 INSTALL(FILES ${incDir}/yajl_version.h DESTINATION include/yajl)
-INSTALL(FILES ${shareDir}/yajl.pc DESTINATION share/pkgconfig)
+INSTALL(FILES ${pkgconfigDir}/yajl.pc DESTINATION lib${LIB_SUFFIX}/pkgconfig)

--- a/src/api/yajl_common.h
+++ b/src/api/yajl_common.h
@@ -42,6 +42,12 @@ extern "C" {
 #  endif
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+#  define YAJL_FALLTHROUGH __attribute__((fallthrough))
+#else
+#  define YAJL_FALLTHROUGH
+#endif
+
 /** pointer to a malloc function, supporting client overriding memory
  *  allocation routines */
 typedef void * (*yajl_malloc_func)(void *ctx, size_t sz);

--- a/src/api/yajl_parse.h
+++ b/src/api/yajl_parse.h
@@ -35,7 +35,7 @@ extern "C" {
         yajl_status_ok,
         /** a client callback returned zero, stopping the parse */
         yajl_status_client_canceled,
-        /** An error occured during the parse.  Call yajl_get_error for
+        /** An error occurred during the parse.  Call yajl_get_error for
          *  more information about the encountered error */
         yajl_status_error
     } yajl_status;
@@ -192,7 +192,7 @@ extern "C" {
      *  parse.
      *
      *  If verbose is non-zero, the message will include the JSON
-     *  text where the error occured, along with an arrow pointing to
+     *  text where the error occurred, along with an arrow pointing to
      *  the specific char.
      *
      *  \returns A dynamically allocated string will be returned which should
@@ -211,7 +211,7 @@ extern "C" {
      *
      * In the event an error is encountered during parsing, this function
      * affords the client a way to get the offset into the most recent
-     * chunk where the error occured.  0 will be returned if no error
+     * chunk where the error occurred.  0 will be returned if no error
      * was encountered.
      */
     YAJL_API size_t yajl_get_bytes_consumed(yajl_handle hand);

--- a/src/yajl.pc.cmake
+++ b/src/yajl.pc.cmake
@@ -1,6 +1,6 @@
 prefix=${CMAKE_INSTALL_PREFIX}
 libdir=${dollar}{prefix}/lib${LIB_SUFFIX}
-includedir=${dollar}{prefix}/include/yajl
+includedir=${dollar}{prefix}/include
 
 Name: Yet Another JSON Library
 Description: A Portable JSON parsing and serialization library in ANSI C

--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -343,6 +343,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                         goto around_again;
                     }
                     /* intentional fall-through */
+                    __attribute__((fallthrough));
                 }
                 case yajl_tok_colon:
                 case yajl_tok_comma:
@@ -394,6 +395,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                         bufLen = yajl_buf_len(hand->decodeBuf);
                     }
                     /* intentional fall-through */
+                    __attribute__((fallthrough));
                 case yajl_tok_string:
                     if (hand->callbacks && hand->callbacks->yajl_map_key) {
                         _CC_CHK(hand->callbacks->yajl_map_key(hand->ctx, buf,

--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -15,6 +15,7 @@
  */
 
 #include "api/yajl_parse.h"
+#include "api/yajl_common.h"
 #include "yajl_lex.h"
 #include "yajl_parser.h"
 #include "yajl_encode.h"
@@ -343,7 +344,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                         goto around_again;
                     }
                     /* intentional fall-through */
-                    __attribute__((fallthrough));
+                    YAJL_FALLTHROUGH;
                 }
                 case yajl_tok_colon:
                 case yajl_tok_comma:
@@ -395,7 +396,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                         bufLen = yajl_buf_len(hand->decodeBuf);
                     }
                     /* intentional fall-through */
-                    __attribute__((fallthrough));
+                    YAJL_FALLTHROUGH;
                 case yajl_tok_string:
                     if (hand->callbacks && hand->callbacks->yajl_map_key) {
                         _CC_CHK(hand->callbacks->yajl_map_key(hand->ctx, buf,
@@ -416,7 +417,7 @@ yajl_do_parse(yajl_handle hand, const unsigned char * jsonText,
                 default:
                     yajl_bs_set(hand->stateStack, yajl_state_parse_error);
                     hand->parseError =
-                        "invalid object key (must be a string)"; 
+                        "invalid object key (must be a string)";
                     goto around_again;
             }
         }

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -272,7 +272,6 @@ static int handle_string (void *ctx,
                           const unsigned char *string, size_t string_length)
 {
     yajl_val v;
-    int ret_val = 0;
 
     v = value_alloc (yajl_t_string);
     if (v == NULL)
@@ -286,14 +285,8 @@ static int handle_string (void *ctx,
     }
     memcpy(v->u.string, string, string_length);
     v->u.string[string_length] = 0;
-	
-    ret_val = (context_add_value (ctx, v) == 0) ? STATUS_CONTINUE : STATUS_ABORT;
-    
-    //If the requested memory is not released in time, it will cause memory leakage   
-    free (v->u.string);
-    free (v);
 
-    return ret_val;
+    return ((context_add_value (ctx, v) == 0) ? STATUS_CONTINUE : STATUS_ABORT);
 }
 
 static int handle_number (void *ctx, const char *string, size_t string_length)

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -456,6 +456,9 @@ yajl_val yajl_tree_parse (const char *input,
              yajl_tree_free(v);
         }
         yajl_free (handle);
+	//If the requested memory is not released in time, it will cause memory leakage
+	if(ctx.root)
+	     yajl_tree_free(ctx.root);
         return NULL;
     }
 

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -272,6 +272,7 @@ static int handle_string (void *ctx,
                           const unsigned char *string, size_t string_length)
 {
     yajl_val v;
+    int ret_val = 0;
 
     v = value_alloc (yajl_t_string);
     if (v == NULL)
@@ -285,8 +286,14 @@ static int handle_string (void *ctx,
     }
     memcpy(v->u.string, string, string_length);
     v->u.string[string_length] = 0;
+	
+    ret_val = (context_add_value (ctx, v) == 0) ? STATUS_CONTINUE : STATUS_ABORT;
+    
+    //If the requested memory is not released in time, it will cause memory leakage   
+    free (v->u.string);
+    free (v);
 
-    return ((context_add_value (ctx, v) == 0) ? STATUS_CONTINUE : STATUS_ABORT);
+    return ret_val;
 }
 
 static int handle_number (void *ctx, const char *string, size_t string_length)

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -143,7 +143,7 @@ static yajl_val context_pop(context_t *ctx)
     ctx->stack = stack->next;
 
     v = stack->value;
-
+    free (stack->key);
     free (stack);
 
     return (v);
@@ -443,6 +443,10 @@ yajl_val yajl_tree_parse (const char *input,
                      strlen(input));
              snprintf(error_buffer, error_buffer_size, "%s", internal_err_str);
              YA_FREE(&(handle->alloc), internal_err_str);
+        }
+        while(ctx.stack != NULL) {
+             yajl_val v = context_pop(&ctx);
+             yajl_tree_free(v);
         }
         yajl_free (handle);
         return NULL;

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -449,6 +449,9 @@ yajl_val yajl_tree_parse (const char *input,
              yajl_tree_free(v);
         }
         yajl_free (handle);
+	//If the requested memory is not released in time, it will cause memory leakage
+	if(ctx.root)
+	     yajl_tree_free(ctx.root);
         return NULL;
     }
 

--- a/test/api/run_tests.sh
+++ b/test/api/run_tests.sh
@@ -5,7 +5,7 @@ echo Running api tests:
 tests=0
 passed=0
 
-for file in `ls`; do
+for file in `ls ../../build/test/api`; do
     [ ! -x $file -o -d $file ] && continue
     tests=`expr 1 + $tests`
     printf " test(%s): " $file

--- a/test/parsing/run_tests.sh
+++ b/test/parsing/run_tests.sh
@@ -16,11 +16,11 @@ fi
 # find test binary on both platforms.  allow the caller to force a
 # particular test binary (useful for non-cmake build systems).
 if [ -z "$testBin" ]; then
-    testBin="../build/test/parsing/Release/yajl_test.exe"
+    testBin="../../build/test/parsing/Release/yajl_test.exe"
     if [ ! -x $testBin ] ; then
-        testBin="../build/test/parsing/Debug/yajl_test.exe"
+        testBin="../../build/test/parsing/Debug/yajl_test.exe"
         if [ ! -x $testBin ] ; then
-            testBin="../build/test/parsing/yajl_test"
+            testBin="../../build/test/parsing/yajl_test"
             if [  ! -x $testBin ] ; then
                 ${ECHO} "cannot execute test binary: '$testBin'"
                 exit 1;

--- a/verify/CMakeLists.txt
+++ b/verify/CMakeLists.txt
@@ -26,7 +26,7 @@ LINK_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
 
 ADD_EXECUTABLE(json_verify ${SRCS})
 
-TARGET_LINK_LIBRARIES(json_verify yajl_s)
+TARGET_LINK_LIBRARIES(json_verify yajl)
 
 # copy in the binary
 GET_TARGET_PROPERTY(binPath json_verify LOCATION)


### PR DESCRIPTION
Alternatively a `/* fall through */` marker comment could work but I think this is more reliable since the preprocessor removes comments which could interfere with tools such as ccache that use it.